### PR TITLE
feat: Add shape and clipBehavior parameters to showModalBottomSheet

### DIFF
--- a/lib/picker.dart
+++ b/lib/picker.dart
@@ -207,12 +207,16 @@ class Picker {
       bool isScrollControlled = false,
       bool useRootNavigator = false,
       Color? backgroundColor,
+      ShapeBorder? shape,
+      Clip? clipBehavior,
       PickerWidgetBuilder? builder}) async {
     return await material.showModalBottomSheet<T>(
         context: context, //state.context,
         isScrollControlled: isScrollControlled,
         useRootNavigator: useRootNavigator,
         backgroundColor: backgroundColor,
+        shape: shape,
+        clipBehavior: clipBehavior,
         builder: (BuildContext context) {
           final picker = makePicker(themeData, true);
           return builder == null ? picker : builder(context, picker);


### PR DESCRIPTION
This allows someone to modify the shape of the modal window (like adding rounded corners to the top).

Example:
```dart
    ...
    ).showModal(
      context,
      clipBehavior: Clip.antiAlias,
      shape: RoundedRectangleBorder(
        borderRadius: BorderRadius.vertical(
          top: Radius.circular(18),
        ),
      ),
    );

```