### PR TITLE
Respect textScaler of the picker if postfix or suffix is set in NumberPickerAdapter

### DIFF
--- a/lib/picker.dart
+++ b/lib/picker.dart
@@ -1187,10 +1187,28 @@ abstract class PickerAdapter<T> {
   Widget makeTextEx(
       Widget? child, String text, Widget? postfix, Widget? suffix, bool isSel) {
     List<Widget> items = [];
-    if (postfix != null) items.add(postfix);
-    items.add(
-        child ?? Text(text, style: (isSel ? picker!.selectedTextStyle : null)));
-    if (suffix != null) items.add(suffix);
+    if (postfix != null) {
+      if (postfix is Text) {
+        final styledPostfix = _styleTextWidget(postfix);
+        items.add(styledPostfix);
+      } else {
+        items.add(postfix);
+      }
+    }
+    items.add(child ??
+        Text(
+          text,
+          style: (isSel ? picker!.selectedTextStyle : null),
+          textScaler: picker!.textScaler,
+        ));
+    if (suffix != null) {
+      if (suffix is Text) {
+        final styledSuffix = _styleTextWidget(suffix);
+        items.add(styledSuffix);
+      } else {
+        items.add(suffix);
+      }
+    }
     final theme = picker!.textStyle != null || picker!.state?.context == null
         ? null
         : material.Theme.of(picker!.state!.context);
@@ -1222,6 +1240,28 @@ abstract class PickerAdapter<T> {
             child: Wrap(
               children: items,
             )));
+  }
+
+  /// Applies the text style and the text scaler of the picker (if available) to a text widget.
+  Text _styleTextWidget(final Text text) {
+    return Text(
+      text.data ?? "",
+      style: text.style ?? picker?.textStyle,
+      textScaler: text.textScaler ?? picker?.textScaler,
+      textAlign: text.textAlign,
+      maxLines: text.maxLines,
+      overflow: text.overflow,
+      softWrap: text.softWrap,
+      textDirection: text.textDirection,
+      locale: text.locale,
+      strutStyle: text.strutStyle,
+      textWidthBasis: text.textWidthBasis,
+      textHeightBehavior: text.textHeightBehavior,
+      semanticsLabel: text.semanticsLabel,
+      selectionColor: text.selectionColor,
+      semanticsIdentifier: text.semanticsIdentifier,
+      key: text.key,
+    );
   }
 
   String getText() {


### PR DESCRIPTION
I discovered that the textScaler property of the Picker is not used if a suffix or prefix is added.

Here the textScaler of the Picker was set to `textScaler: TextScaler.noScaling` but only the text without suffix and prefix used the defined scaler (image 1, right column). 
<img width="1206" height="2622" alt="without_fix" src="https://github.com/user-attachments/assets/e2e00e7a-311d-4b04-9f05-08a75608c71a" />

With this fix it looks like this:

<img width="1206" height="2622" alt="with_fix" src="https://github.com/user-attachments/assets/58945a18-0b9e-4229-bdf6-35215288662f" />

Also I added that the textStyle and textScaler of the Picker is applied to suffixes and postfixes of type Text. This is just a "nice-to-have-thing", I would say.